### PR TITLE
Add GitHub Action workflow for preview package publishing

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,0 +1,71 @@
+name: Publish Preview Packages
+
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/ci-setup
+
+      - name: Configure npm for GitHub Packages
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Generate version string
+        id: version
+        run: |
+          BRANCH="${GITHUB_REF_NAME}"
+          # Sanitize branch name for npm (replace invalid chars with -)
+          BRANCH_SAFE=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')
+          SHORT_SHA="${GITHUB_SHA::7}"
+          VERSION="0.0.0-${BRANCH_SAFE}.${SHORT_SHA}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing version: $VERSION"
+
+      - name: Update package version
+        run: pnpm version ${{ steps.version.outputs.version }} --no-git-tag-version
+
+      - name: Publish package
+        run: pnpm publish --access public --tag preview --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## Published Package" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Version: \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Install with:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "pnpm add @casekit/unindent@${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+  cleanup:
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      packages: write
+
+    steps:
+      - name: Delete old preview versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: unindent
+          package-type: npm
+          min-versions-to-keep: 50
+          delete-only-pre-release-versions: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
         "vitest": "^1.1.1"
     },
     "author": "Russell Dunphy",
-    "license": "ISC"
+    "license": "ISC",
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com"
+    }
 }

--- a/src/unindent.test.ts
+++ b/src/unindent.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { unindent } from "#unindent";
+import { unindent } from "./unindent";
 
 describe("unindent", () => {
     test("it strips whitespace from the left-hand side of multiline strings", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        exclude: ["build/**", "node_modules/**"],
+    },
+});


### PR DESCRIPTION
Automatically publishes every commit to GitHub Packages with a version like 0.0.0-branch.sha, tagged as 'preview'. Keeps the 50 most recent preview versions.